### PR TITLE
bugfix to accomodate @ symbol in filenames

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var through2 = require("through2"),
         fileNameRegExpObj: {
             start: "\\/\\*splitfilename=",
             end: "\\*\\/",
-            filename: "([\\w\\.\\-]+)"
+            filename: "([\\w\\.\\-\\@]+)"
         },
         getFileNameRegExp: function () {
             var fnreo = splitFiles.fileNameRegExpObj;


### PR DESCRIPTION
Added the `@` to the filename regex to accommodate filenames that may have `@2x` in them referring to retina sprite sheets or similar files. This will eliminate the plugin from falling back to incremental numbers instead of using the specified filenames in the comments.